### PR TITLE
Implemented global imports

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,5 +3,6 @@ module.exports = {
     header: "#built using mc-build (https://github.com/mc-build/mc-build)",
     internalScoreboard: "LANG_MC_INTERNAL",
     generatedDirectory: "__generated__",
+    globalImports:[],
     rootNamespace: null
 };

--- a/entry.js
+++ b/entry.js
@@ -1338,6 +1338,17 @@ function MC_LANG_HANDLER(file) {
   resetScoreIdsForFile(file);
   hashes = new Map();
   Macros = {};
+  if(CONFIG.hasOwnProperty("globalImports")) {
+    CONFIG.globalImports.forEach((x)=>{
+      Macros = Object.assign(
+        Macros,
+        getMacro(
+            path.resolve(SRC_DIR, x),
+          file
+        )
+      );
+    });
+  }
   included_file_list = [];
   const location = path.relative(SRC_DIR, file);
   namespaceStack = [


### PR DESCRIPTION
To use it, you have to add a property called `globalImports` in the `mc` config with a value that is an array containing the path, relative to the `src` folder, of all imports.

Ex:
```js
module.exports = {
  "global": {
    [...]
  },
  "mc": {
    [...]
    "globalImports":["foo/bar_macros.mcm"],
  }
}
```